### PR TITLE
Create gpx

### DIFF
--- a/lib/recorder/files.py
+++ b/lib/recorder/files.py
@@ -1,0 +1,48 @@
+import asyncio
+from model.db import Rides, Gpsreadings, Hrreadings, Powerreadings, Enviroreadings
+
+import gpxpy
+import gpxpy.gpx
+from datetime import datetime
+from xml.etree import ElementTree
+
+def get_point(lat, lon, ele, power, temp, hr, cadence, time):
+    # Create point:
+    gpx_point = gpxpy.gpx.GPXTrackPoint(lat, lon, elevation=ele, time=time)
+    gpx_extension_power = ElementTree.fromstring(f"""<power>{power}</power>""")
+    gpx_extension_hr = ElementTree.fromstring(f"""<gpxtpx:TrackPointExtension xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1">
+        <gpxtpx:atemp>{temp}</gpxtpx:atemp>
+        <gpxtpx:hr>{hr}</gpxtpx:hr>
+        <gpxtpx:cad>{cadence}</gpxtpx:cad>
+        </gpxtpx:TrackPointExtension>
+    """)
+    gpx_point.extensions.append(gpx_extension_power)
+    gpx_point.extensions.append(gpx_extension_hr)
+    return gpx_point
+
+async def generate_gpx(id):
+    """Generate GPX file from a ride in the DB"""
+    print("Saving GPX file for ride {}".format(id))
+    loc = await Gpsreadings.objects.filter(ride_id=id).all()
+    hr = await Hrreadings.objects.filter(ride_id=id).all()
+    power = await Powerreadings.objects.filter(ride_id=id).all()
+    enviro = await Enviroreadings.objects.filter(ride_id=id).all()
+
+    gpx = gpxpy.gpx.GPX()
+    # Add TrackPointExtension namespace
+    gpx.nsmap["gpxtpx"] = "http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
+    # Create track
+    gpx_track = gpxpy.gpx.GPXTrack()
+    gpx.tracks.append(gpx_track)
+    # Create segment
+    gpx_segment = gpxpy.gpx.GPXTrackSegment()
+    gpx_track.segments.append(gpx_segment)
+
+    for x in range(len(loc)):
+        point = get_point(loc[x].latitude,loc[x].longitude, loc[x].altitude, power[x].power, enviro[x].temp, hr[x].bpm, power[x].cadence, loc[x].timestamp)
+        gpx_segment.points.append(point)
+    
+    # Create GPX file with current datetime
+    filename = "data/" + datetime.now().strftime("%Y_%m_%d-%I_%M_%S_%p") + ".gpx"
+    with open(filename, "w") as f:
+        f.write( gpx.to_xml())

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from sensors.ble.discover import discover_devices
 from sensors import gps
 from sensors import ioexpander 
 from sensors import bmp388
+from lib.recorder.files import generate_gpx
 
 # Globals
 app = FastAPI()
@@ -156,6 +157,10 @@ async def connect_ble_devices():
     else:
         print("You don't have any BLE devices paired, please pair one!")
         return {"status": "You don't have any BLE devices paired, please pair one!"}
+
+@app.get("/save/{ride_id}")
+async def save_gpx(ride_id):
+    return await generate_gpx(ride_id)
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):

--- a/main.py
+++ b/main.py
@@ -202,7 +202,7 @@ async def startup() -> None:
     enviro_task = asyncio.create_task(bmp388.monitor_pressure_temp(hypecycleState))
     button_task = asyncio.create_task(ioexpander.monitor_buttons(hypecycleState))
     battery_task = asyncio.create_task(ioexpander.monitor_battery(hypecycleState))
-    recorder_task = asyncio.create_task(recorder.monitor_recording(hypecycleState,interval=10))
+    recorder_task = asyncio.create_task(recorder.monitor_recording(hypecycleState,interval=1))
 
 @app.on_event("shutdown")
 async def shutdown() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,9 @@ pimoroni-ioexpander
 # Camera
 picamera2
 
+# GPX 
+gpxpy==1.5.0
+
 
 
 

--- a/sensors/ioexpander/__init__.py
+++ b/sensors/ioexpander/__init__.py
@@ -3,6 +3,9 @@ import time
 import asyncio
 import ioexpander as io
 
+import gpxpy
+import gpxpy.gpx
+
 from model.db import Rides
 
 BTN_1 = 14
@@ -49,6 +52,8 @@ async def monitor_buttons(state):
                     # Change ride active state to false
                     ride = await cur_ride.update(active=False) # TODO: add endtime stamp here
                     print("Stop ride requested by button press...")
+                    # Generate GPX file.
+
                 else:
                     print("No active ride to stop... so starting a new ride")
                     # Create a new ride TODO: Generate interesting names here

--- a/sensors/ioexpander/__init__.py
+++ b/sensors/ioexpander/__init__.py
@@ -7,6 +7,7 @@ import gpxpy
 import gpxpy.gpx
 
 from model.db import Rides
+from lib.recorder.files import generate_gpx
 
 BTN_1 = 14
 BTN_2 = 12
@@ -53,7 +54,7 @@ async def monitor_buttons(state):
                     ride = await cur_ride.update(active=False) # TODO: add endtime stamp here
                     print("Stop ride requested by button press...")
                     # Generate GPX file.
-
+                    await generate_gpx(ride.id)
                 else:
                     print("No active ride to stop... so starting a new ride")
                     # Create a new ride TODO: Generate interesting names here


### PR DESCRIPTION
Add ability to create gpx files in /data folder when:
1.) the stop/start button is pressed during an active ride to end the ride
2.) via the /save/{ride_id} api path.

The gpx files are currently saved with a timestamp name of when the file is created.